### PR TITLE
Add Mopidy-Soundcloud backend

### DIFF
--- a/cookbooks/mopidy-jukebox/files/default/requirements.txt
+++ b/cookbooks/mopidy-jukebox/files/default/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --output-file cookbooks/mopidy-jukebox/files/default/requirements.txt requirements.in
 #
--e file:///home/theo.lawson/Documents/Repos/mopidly/mopidy-cacher
--e file:///home/theo.lawson/Documents/Repos/mopidly/mopidy-musicbox-webclient
+-e mopidy-cacher
+-e mopidy-musicbox-webclient
 -e git+https://github.com/mopidy/mopidy-soundcloud.git@faeb6710980f12b50b03bf78c1878be751b8e21a#egg=Mopidy-SoundCloud
 -e git+https://github.com/chatziko/mopidy-youtube@performance-improvements-3#egg=Mopidy-Youtube
 asn1crypto==0.22.0        # via cryptography

--- a/cookbooks/mopidy-jukebox/files/default/requirements.txt
+++ b/cookbooks/mopidy-jukebox/files/default/requirements.txt
@@ -4,8 +4,9 @@
 #
 #    pip-compile --output-file cookbooks/mopidy-jukebox/files/default/requirements.txt requirements.in
 #
--e mopidy-cacher
--e mopidy-musicbox-webclient
+-e file:///home/theo.lawson/Documents/Repos/mopidly/mopidy-cacher
+-e file:///home/theo.lawson/Documents/Repos/mopidly/mopidy-musicbox-webclient
+-e git+https://github.com/mopidy/mopidy-soundcloud.git@faeb6710980f12b50b03bf78c1878be751b8e21a#egg=Mopidy-SoundCloud
 -e git+https://github.com/chatziko/mopidy-youtube@performance-improvements-3#egg=Mopidy-Youtube
 asn1crypto==0.22.0        # via cryptography
 backports-abc==0.4        # via tornado
@@ -13,7 +14,7 @@ cachetools==1.1.6
 certifi==2015.4.28
 cffi==1.7.0               # via cryptography
 click==6.6                # via pip-tools
-cryptography==1.9
+cryptography==2.2.1
 decorator==4.0.10         # via validators
 enum34==1.1.6             # via cryptography
 first==2.0.1              # via pip-tools
@@ -23,12 +24,12 @@ mopidy-local-sqlite==1.0.0
 mopidy-tachikoma==0.2.4
 mopidy==2.0.1
 ndg-httpsclient==0.4.2    # via requests
-pafy==0.5.1
+pafy==0.5.4
 pip-tools==1.9.0
 pyasn1==0.1.9             # via requests
 pycparser==2.14           # via cffi
 pykka==1.2.1              # via mopidy, mopidy-local-sqlite, mopidy-tachikoma
-pyopenssl==16.0.0         # via ndg-httpsclient, requests
+pyopenssl==17.5.0
 pysqlite==2.8.2
 requests[security]==2.10.0
 singledispatch==3.4.0.3   # via tornado

--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,10 @@ Mopidy-Local-SQLite
 
 # Switch Mopidy-Youtube back to normal once https://github.com/mopidy/mopidy-youtube/pull/46 is merged
 -e git+https://github.com/chatziko/mopidy-youtube@performance-improvements-3#egg=Mopidy-Youtube
+
+# mopidy-youtube repo recommends upgrading pafy if youtube URI resolution starts to fail. Prior to figuring out that the
+# problem was actually the API key, upgrading to the latest version was attempted. This can be potentially be removed
+# in favour of letting the plugin manage it's own dependencies.
 pafy>=0.5.4
 
 pip-tools==1.9.0
@@ -17,6 +21,10 @@ Mopidy-Tachikoma>=0.2.4
 # Fixes https://github.com/pyca/cryptography/issues/2750 and https://github.com/pyca/cryptography/pull/2826
 # Also https://github.com/pyca/cryptography/issues/3605
 cryptography>=1.9
+
+# pyOpenSSL v16.0.0 was causing the python error AttributeError: 'module' object has no attribute 'SSL_ST_INIT' on
+# running mopidy. This version does not cause that, and prevents the user from having to manually pip
+# un-/re-install the pyOpenSSL module to get the jukebox to work.
 pyOpenSSL>=17.5.0
 
 youtube-dl>=2017.12.14

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ Mopidy-Tachikoma>=0.2.4
 # Fixes https://github.com/pyca/cryptography/issues/2750 and https://github.com/pyca/cryptography/pull/2826
 # Also https://github.com/pyca/cryptography/issues/3605
 cryptography>=1.9
-pyopenssl>=17.0.0
+pyOpenSSL>=17.5.0
 
 youtube-dl>=2017.12.14
-Mopidy-SoundCloud>=2.0.2
+-e git+https://github.com/mopidy/mopidy-soundcloud.git@faeb6710980f12b50b03bf78c1878be751b8e21a#egg=Mopidy-SoundCloud

--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,7 @@ Mopidy-Local-SQLite
 
 # Switch Mopidy-Youtube back to normal once https://github.com/mopidy/mopidy-youtube/pull/46 is merged
 -e git+https://github.com/chatziko/mopidy-youtube@performance-improvements-3#egg=Mopidy-Youtube
+pafy>=0.5.4
 
 pip-tools==1.9.0
 pysqlite
@@ -16,5 +17,7 @@ Mopidy-Tachikoma>=0.2.4
 # Fixes https://github.com/pyca/cryptography/issues/2750 and https://github.com/pyca/cryptography/pull/2826
 # Also https://github.com/pyca/cryptography/issues/3605
 cryptography>=1.9
+pyopenssl>=17.0.0
 
 youtube-dl>=2017.12.14
+Mopidy-SoundCloud>=2.0.2


### PR DESCRIPTION
Specific version of the Mopidy-Soundcloud was chosen that was stable and didn't attempt to access invalid APIs.