### PR TITLE
Revert version upgrade on cachetools

### DIFF
--- a/cookbooks/mopidy-jukebox/files/default/requirements.txt
+++ b/cookbooks/mopidy-jukebox/files/default/requirements.txt
@@ -10,7 +10,7 @@
 -e git+https://github.com/chatziko/mopidy-youtube@performance-improvements-3#egg=Mopidy-Youtube
 asn1crypto==0.24.0        # via cryptography
 backports-abc==0.5        # via tornado
-cachetools==3.0.0
+cachetools==1.1.6
 certifi==2018.10.15
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests

--- a/requirements.in
+++ b/requirements.in
@@ -28,5 +28,6 @@ cryptography>=1.9.0
 pyOpenSSL>=17.5.0
 
 youtube-dl==2017.12.14
+# Use older version of cachetools as Mopidy-Youtube breaks otherwise;
 cachetools==1.1.6
 -e git+https://github.com/mopidy/mopidy-soundcloud.git@faeb6710980f12b50b03bf78c1878be751b8e21a#egg=Mopidy-SoundCloud

--- a/requirements.in
+++ b/requirements.in
@@ -28,4 +28,5 @@ cryptography>=1.9.0
 pyOpenSSL>=17.5.0
 
 youtube-dl==2017.12.14
+cachetools==1.1.6
 -e git+https://github.com/mopidy/mopidy-soundcloud.git@faeb6710980f12b50b03bf78c1878be751b8e21a#egg=Mopidy-SoundCloud


### PR DESCRIPTION
Newer version crashes Mopidy-Youtube extension, which hasn't been
updated in two years already